### PR TITLE
Only enable Sentry in production

### DIFF
--- a/website/website/settings.py
+++ b/website/website/settings.py
@@ -154,11 +154,12 @@ DJANGO_TABLES2_TEMPLATE = "django_tables2/bootstrap4.html"
 # sentry-sdk
 # https://docs.sentry.io/platforms/python/guides/django/
 
-if not DEBUG:
+SENTRY_DSN = getenv("SENTRY_DSN", None)
+if SENTRY_DSN:
     sentry_sdk.init(
         # This key is safe to store in version control
         # Learn more here: https://docs.sentry.io/product/sentry-basics/dsn-explainer/
-        dsn="https://a36fac205d4a42cb9fcff9c11355707b@o477092.ingest.sentry.io/5517507",
+        dsn=SENTRY_DSN,
         integrations=[DjangoIntegration()],
         traces_sample_rate=1.0,
 


### PR DESCRIPTION
Use the presence of the SENTRY_DSN environment variable to enable
sending to Sentry. Prevents us from sending errors from our local
environments that are under development.