### PR TITLE
Increase fuzziness in geocoder

### DIFF
--- a/website/volunteers/templates/volunteers/delivery_signup.html
+++ b/website/volunteers/templates/volunteers/delivery_signup.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load bootstrap4 %}
+{% load get_volunteer %}
 
 {% block content %}
 <h1 class="mb-3">Sign up to deliver meals and groceries (Toronto)</h1>
@@ -39,7 +40,7 @@
                 width="350"
                 height="200"
                 frameborder="0" style="border:0"
-                src="{{ delivery.chef.anonymous_map_embed }}&zoom=14" allowfullscreen>
+                src="{{ delivery.chef|get_volunteer:'anonymous_map_embed' }}&zoom=14" allowfullscreen>
               </iframe>
             </div>
             <div class="col">

--- a/website/website/maps.py
+++ b/website/website/maps.py
@@ -10,8 +10,8 @@ class GeocoderException(Exception):
 
 class Geocoder:
     API_BASE_URL = "http://mapquestapi.com/geocoding/v1"
-    DEGREE_RANGE_LOWER = 0.0004
-    DEGREE_RANGE_HIGHER = 0.0008
+    DEGREE_RANGE_LOWER = 0.001
+    DEGREE_RANGE_HIGHER = 0.004
 
     def __init__(self, api_key=MAPQUEST_API_KEY):
         self.api_key = api_key
@@ -21,7 +21,7 @@ class Geocoder:
         latitude, longitude = self.geocode(address)
         latitude += self.generate_noise()
         longitude += self.generate_noise()
-        return latitude, longitude
+        return round(latitude, 3), round(longitude, 3)
 
     def geocode(self, address):
         """Given an address, return the latitude & longitude"""


### PR DESCRIPTION
Our previous values created between 100-200 feet of fuzziness to the marker, which is too low for the purposes of preventing abuse imo. The new values create between 250-1000 feet of fuzziness and rounds it for extra measure.