### PR TITLE
Add recurring links

### DIFF
--- a/website/public/templates/public/index.html
+++ b/website/public/templates/public/index.html
@@ -11,7 +11,7 @@
 				<span class="h3">Request free meals or groceries</span>
 			</a>
 			<div class="mt-2">
-				<a href="https://www.gofundme.com/f/the-people039s-pantry-covid19-emergency-meal-fund" class="btn btn-info m-2" target="_blank" rel="noopener noreferrer">
+				<a href="https://donorbox.org/thepeoplespantryto" class="btn btn-info m-2" target="_blank" rel="noopener noreferrer">
 					<span class="h4">Donate</span>
 				</a>
 				<a href="{% url 'signup' %}" class="btn btn-info m-2">
@@ -31,7 +31,7 @@
 		  and the elderly.
 		</p>
 		<p>
-		  In response to the pandemic, The People's Pantry is a grassroots initiative providing
+		  The People's Pantry <a href="https://www.gofundme.com/f/the-people039s-pantry-covid19-emergency-meal-fund" target="_blank" rel="noopener noreferrer">launched in response to this urgent need</a>. We are a completely volunteer-run, grassroots initiative providing
 		  home-cooked meals and grocery bundles to individuals and families across the GTA who
 		  have been disproportionately affected by the COVID-19 crisis.
 		  We serve those who are struggling financially or are otherwise unable to provide

--- a/website/templates/nav.html
+++ b/website/templates/nav.html
@@ -76,6 +76,6 @@
       </li>
     </ul>
     {% endif %}
-    <a class="btn btn-info ml-3" href="https://www.gofundme.com/f/the-people039s-pantry-covid19-emergency-meal-fund" target="_blank" rel="noopener noreferrer">Donate</a>
+    <a class="btn btn-info ml-3" href="https://donorbox.org/thepeoplespantryto" target="_blank" rel="noopener noreferrer">Donate</a>
   </div>
 </nav>


### PR DESCRIPTION
Decided to replace current donate links with links to donorbox, and added a link to the GFM from the homepage as part of our "story". Operating under the assumption that we would like to encourage recurring donations where possible, and donorbox ALSO allows onetime donations, so it seemed like a better central place to point people to. 

Resolves #132 