### PR TITLE
Remove grocery specifications from form

### DIFF
--- a/website/recipients/forms.py
+++ b/website/recipients/forms.py
@@ -1,6 +1,6 @@
 from textwrap import dedent
 from django import forms
-from .models import MealRequest, GroceryRequest, Vegetables, Fruits, Grains, Condiments
+from .models import MealRequest, GroceryRequest, Vegetables, Fruits, Grains, Condiments, Protein, Dairy
 
 
 class TelephoneInput(forms.TextInput):
@@ -73,4 +73,12 @@ class GroceryRequestForm(HelpRequestForm):
         required=False,
         widget=forms.CheckboxSelectMultiple,
         choices=Condiments.choices,
+    )
+    protein = forms.ChoiceField(
+        required=False,
+        choices=Protein.choices,
+    )
+    dairy = forms.ChoiceField(
+        required=False,
+        choices=Dairy.choices,
     )

--- a/website/recipients/templates/recipients/new_grocery_request.html
+++ b/website/recipients/templates/recipients/new_grocery_request.html
@@ -22,6 +22,9 @@
 {% endblock pre_details_section %}
 
 {% block details_section_extras %}
+{% comment %}
+When we first kick off the grocery launch, recipients will not be able to request specific groceries
+We intend to add this feature back in after the holidays
 {% bootstrap_field form.vegetables %}
 {% bootstrap_field form.fruits %}
 {% bootstrap_field form.protein %}
@@ -31,4 +34,5 @@
 {% bootstrap_field form.baked_goods %}
 {% bootstrap_field form.kid_snacks %}
 {% bootstrap_field form.hygiene_products %}
+{% endcomment %}
 {% endblock details_section_extras %}


### PR DESCRIPTION
Fixes #154 
Prevents recipients from being able to choose which groceries they want. Leaves the code in, because we intend to add this back later