### PR TITLE
Allow custom redirects for user-not-in-group

### DIFF
--- a/website/public/views.py
+++ b/website/public/views.py
@@ -1,5 +1,6 @@
 from django.shortcuts import render, redirect
 from django.contrib.auth.mixins import UserPassesTestMixin
+from django.urls import reverse
 
 from core.models import has_group
 
@@ -12,5 +13,9 @@ class GroupView(UserPassesTestMixin):
     def test_func(self):
         return has_group(self.request.user, self.permission_group) or self.request.user.is_staff
 
+    def get_permission_group_redirect_url(self):
+        default = reverse('profile')
+        return getattr(self, 'permission_group_redirect_url', default)
+
     def handle_no_permission(self):
-        return redirect('/accounts/profile')
+        return redirect(self.get_permission_group_redirect_url())

--- a/website/volunteers/views.py
+++ b/website/volunteers/views.py
@@ -27,6 +27,7 @@ class ChefSignupView(LoginRequiredMixin, GroupView, FormView, FilterView):
     template_name = "volunteers/chef_signup.html"
     form_class = ChefSignupForm
     permission_group = 'Chefs'
+    permission_group_redirect_url = reverse_lazy('volunteers:chef_application')
     filterset_class = ChefSignupFilter
     queryset = MealRequest.objects.filter(delivery__isnull=True).order_by('created_at')
 
@@ -110,6 +111,7 @@ class ChefIndexView(TaskIndexView):
     """View for chefs to see the meals they've signed up to cook"""
     template_name = "volunteers/chef_list.html"
     permission_group = 'Chefs'
+    permission_group_redirect_url = reverse_lazy('volunteers:chef_application')
 
     def get_queryset(self):
         return self.queryset.filter(chef=self.request.user)
@@ -119,6 +121,7 @@ class MealDeliveryIndexView(TaskIndexView):
     """View for deliverers to see the meal requests they've signed up to deliver"""
     template_name = "volunteers/delivery_list.html"
     permission_group = 'Deliverers'
+    permission_group_redirect_url = reverse_lazy('volunteers:delivery_application')
 
     def get_queryset(self):
         return self.queryset.filter(deliverer=self.request.user)
@@ -136,6 +139,7 @@ class MealDeliverySignupView(LoginRequiredMixin, GroupView, FormView, FilterView
     template_name = "volunteers/delivery_signup.html"
     form_class = MealDeliverySignupForm
     permission_group = 'Deliverers'
+    permission_group_redirect_url = reverse_lazy('volunteers:delivery_application')
     filterset_class = MealDeliverySignupFilter
     queryset = MealDelivery.objects.filter(deliverer__isnull=True,).order_by('date')
 


### PR DESCRIPTION
If a permission_group_redirect_url attribute is defined on the view,
redirect the user to the appropriate URL if they fail the check.

Otherwise, default to sending them to the profile view.

This way if someone doesn't have the right permissions to access one of the links in the nav, it'll automatically take them to a place to register for that role.