### PR TITLE
Redirect HTTP -> HTTPS

### DIFF
--- a/website/website/settings.py
+++ b/website/website/settings.py
@@ -178,9 +178,10 @@ LOGOUT_REDIRECT_URL = '/'
 # SSL/HTTPS
 # https://docs.djangoproject.com/en/3.1/topics/security/#ssl-https
 
-SECURE_SSL_REDIRECT = True
-SESSION_COOKIE_SECURE = True
-CSRF_COOKIE_SECURE = True
+if not DEBUG:
+    SECURE_SSL_REDIRECT = True
+    SESSION_COOKIE_SECURE = True
+    CSRF_COOKIE_SECURE = True
 
 
 # sentry-sdk


### PR DESCRIPTION
~⚠️ Don't merge this yet, need to figure out a way to disable this when running with `python manage.py runserver` locally~

I always run with `DEBUG=1` locally so I've just added a flag where it won't enable the SSL settings when debug is on