### PR TITLE
Fix logic in delivery dropoff time

### DIFF
--- a/website/recipients/models.py
+++ b/website/recipients/models.py
@@ -300,8 +300,8 @@ class BaseDelivery(models.Model):
             raise ValidationError("The pickup end time must be after the pickup start time")
         if self.dropoff_end and self.dropoff_start and self.dropoff_end <= self.dropoff_start:
             raise ValidationError("The dropoff end time must be after the dropoff start time")
-        if self.dropoff_start and self.pickup_end and self.dropoff_start < self.pickup_end:
-            raise ValidationError("The delivery timerange must start after the pickup timerange")
+        if self.dropoff_start and self.pickup_start and self.dropoff_start <= self.pickup_start:
+            raise ValidationError("The dropoff start time must be after the pickup start time")
 
     def save(self, *args, **kwargs):
         self.full_clean()


### PR DESCRIPTION
Delivery dropoff start should be allowed to be sooner than the pickup
end time. If a chef says they're available for you to pick it up from
noon to 5pm and you're available to pick it up at 1pm you shouldn't have
to wait until after 5pm to drop it off.

Delivery dropoff start should only be restricted to after the pickup
start window