### PR TITLE
Let organizers see the volunteers and applications

### DIFF
--- a/website/website/settings.py
+++ b/website/website/settings.py
@@ -253,5 +253,7 @@ GROUP_PERMISSIONS = {
         'view_groceryrequestcomment',
         'add_mealdeliverycomment',
         'view_mealdeliverycomment',
+        'view_volunteerapplication',
+        'view_volunteer',
     ]
 }


### PR DESCRIPTION
Organizers should be able to see the volunteers and applications and be able to hit the "approve" button for applications