### PR TITLE
Handle redirect on both get/post

### DIFF
--- a/website/volunteers/views.py
+++ b/website/volunteers/views.py
@@ -327,10 +327,10 @@ class VolunteerApplicationView(LoginRequiredMixin, FormView, UpdateView):
     def get_object(self):
         return Volunteer.objects.get(user=self.request.user)
 
-    def get(self, request, *args, **kwargs):
+    def dispatch(self, request, *args, **kwargs):
         if VolunteerApplication.has_applied(self.request.user, self.role):
             return redirect(self.success_url)
-        return super().get(request, *args, **kwargs)
+        return super().dispatch(request, *args, **kwargs)
 
     def form_valid(self, form):
         organizer_teams = form.cleaned_data.get("organizer_teams", "")


### PR DESCRIPTION
Fixes https://sentry.io/organizations/the-peoples-pantry/issues/2126062096/

This way if the user "double posts" the form it won't throw an integrity
error the second time. This could happen because the server received the
first POST request, but the client didn't get back the response so they
tried again, perhaps with a browser refresh.

With this change, the second POST (refresh) would go through as normal
if the first request hadn't been received, and would redirect instead if
the first post had been.