### PR TITLE
Don't show "Delivered" requests on the delivery signup page

### DIFF
--- a/website/volunteers/views.py
+++ b/website/volunteers/views.py
@@ -193,7 +193,7 @@ class MealDeliverySignupView(LoginRequiredMixin, GroupView, FormView, FilterView
     permission_group = 'Deliverers'
     permission_group_redirect_url = reverse_lazy('volunteers:delivery_application')
     filterset_class = MealDeliverySignupFilter
-    queryset = MealDelivery.objects.filter(deliverer__isnull=True,).order_by('date')
+    queryset = MealDelivery.objects.exclude(status=Status.DELIVERED).filter(deliverer__isnull=True,).order_by('date')
 
     @property
     def success_url(self):


### PR DESCRIPTION
This can happen if our admins deliberately set something to "Delivered"
without a Deliverer assigned in order to "cancel" or "pause" a request
from showing up in the signup