### PR TITLE
Default children to 0

### DIFF
--- a/website/recipients/views.py
+++ b/website/recipients/views.py
@@ -21,6 +21,9 @@ class MealRequestView(FormView):
     template_name = 'recipients/new_meal_request.html'
     success_url = reverse_lazy('recipients:success')
     form_class = MealRequestForm
+    initial = {
+        'num_children': 0,
+    }
 
     def dispatch(self, request):
         if MealRequest.requests_paused():
@@ -48,6 +51,9 @@ class GroceryRequestView(FormView):
     template_name = 'recipients/new_grocery_request.html'
     success_url = reverse_lazy('recipients:success')
     form_class = GroceryRequestForm
+    initial = {
+        'num_children': 0,
+    }
 
     def dispatch(self, request):
         if GroceryRequest.requests_paused():


### PR DESCRIPTION
People sometimes skip over this field when they don't have children, not
realizing that its a required value and then they have to input it.

This sets it to zero by default, allowing them to increment if needed