### PR TITLE
Update the "prior to the website" count of grocery deliveries

### DIFF
--- a/website/public/views.py
+++ b/website/public/views.py
@@ -8,7 +8,7 @@ from recipients.models import MealRequest, GroceryRequest
 class IndexView(TemplateView):
     template_name = "public/index.html"
     MEAL_REQUESTS_COUNT_PRIOR_TO_WEBSITE = 15_000
-    GROCERY_REQUESTS_COUNT_PRIOR_TO_WEBSITE = 11_000
+    GROCERY_REQUESTS_COUNT_PRIOR_TO_WEBSITE = 1_988
 
     @property
     def extra_context(self):


### PR DESCRIPTION
Andrea pointed out that this was reflecting the number of _people_ reached, not the number of bundles