### PR TITLE
Remove delete permissions

### DIFF
--- a/website/website/settings.py
+++ b/website/website/settings.py
@@ -279,7 +279,6 @@ GROUP_PERMISSIONS = {
     'Organizers': [
         'add_mealrequest',
         'change_mealrequest',
-        'delete_mealrequest',
         'view_mealrequest',
         'add_mealrequestcomment',
         'view_mealrequestcomment',
@@ -289,7 +288,6 @@ GROUP_PERMISSIONS = {
 
         'add_groceryrequest',
         'change_groceryrequest',
-        'delete_groceryrequest',
         'view_groceryrequest',
         'add_groceryrequestcomment',
         'view_groceryrequestcomment',


### PR DESCRIPTION
Don't allow volunteer organizers to delete meal/grocery requests since
this can't be undone. If they need to delete a request, ask for support
in the #help-website slack channel.
