### PR TITLE
Fix broken CONTRIBUTING link

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ One area in which we have traded off some complexity for convenience is the use 
 
 ## Contributing
 
-We welcome contributions to this project! See our [Contributing guide](/contributing.md) and our [list of open issues](https://github.com/The-Peoples-Pantry/website/issues)
+We welcome contributions to this project! See our [Contributing guide](/CONTRIBUTING.md) and our [list of open issues](https://github.com/The-Peoples-Pantry/website/issues)
 
 [django]: https://www.djangoproject.com/
 [gunicorn]: https://gunicorn.org/


### PR DESCRIPTION
Github is a bit fussy with link casing. Here only changing the contribution link letter casing to upper to match the filename.