### PR TITLE
Render errors on the sign-in/sign-up pages

### DIFF
--- a/website/core/templates/core/signup.html
+++ b/website/core/templates/core/signup.html
@@ -11,6 +11,7 @@
 
 <form action="" method="post" class="form mb-6">
   {% csrf_token %}
+  {% bootstrap_form_errors form %}
   {% bootstrap_form form %}
   <button class="btn btn-block btn-primary mt-5" type="submit">Sign up</button>
 </form>

--- a/website/templates/registration/login.html
+++ b/website/templates/registration/login.html
@@ -19,6 +19,8 @@
   {% csrf_token %}
   <input type="hidden" name="next" value="{{ next }}">
 
+  {% bootstrap_form_errors form %}
+
   {# Django uses the field "username" but we want to clarify that it's your email we're asking for #}
   {% bootstrap_label "Email address" %}
   {% bootstrap_field form.username placeholder="Email address" show_label=False bound_css_class="" %}


### PR DESCRIPTION
RIght now if you fail to login it just resets the page with no failure
indication
