### PR TITLE
case insensitive email username

### DIFF
--- a/website/core/forms.py
+++ b/website/core/forms.py
@@ -47,7 +47,7 @@ class UserCreationForm(forms.ModelForm):
         # Django's user model does not apply a unique constraint on the DB field
         # so we need to perform a manual validation here
         email = self.cleaned_data.get("email")
-        if User.objects.filter(email=email).exists():
+        if User.objects.filter(email__iexact=email).exists():
             raise ValidationError(
                 self.error_messages['already_registered'],
                 code='already_registered',

--- a/website/templates/registration/password_reset_email.html
+++ b/website/templates/registration/password_reset_email.html
@@ -1,4 +1,5 @@
 Reset your password
 
 You're receiving this email because a password reset was requested for {{ email }} for {{ domain }}.
+Please note when logging in that both email and password are case sensitive.
 To reset your password follow this link: {{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}


### PR DESCRIPTION
- Prevent duplicate emails from being registered
- Note in the password reset that email and password are case sensitive
