### PR TITLE
Add a test framework for some new routes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
       # https://docs.djangoproject.com/en/stable/topics/testing/overview/
       - name: Run tests
         working-directory: ./website
-        run: python manage.py test
+        run: python manage.py test --settings=website.test_settings
 
       # Double-check that migrations have been created
       # After making a change to a model, the developer should

--- a/bin/test
+++ b/bin/test
@@ -2,4 +2,4 @@
 
 python -m venv /tmp/venv
 python website/manage.py collectstatic --link --noinput  # static files need to exist for route tests
-python website/manage.py test "${@:-website}"
+python website/manage.py test --settings=website.test_settings "${@:-website}"

--- a/bin/test
+++ b/bin/test
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 python -m venv /tmp/venv
+python website/manage.py collectstatic --link --noinput  # static files need to exist for route tests
 python website/manage.py test "${@:-website}"

--- a/website/public/tests.py
+++ b/website/public/tests.py
@@ -1,3 +1,13 @@
-# from django.test import TestCase
+from django.urls import reverse
+from django.test import TestCase
 
-# Create your tests here.
+
+class IndexViewTest(TestCase):
+    def test_something(self):
+        url = reverse("public:index")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            "We provide home cooked meals and groceries to those who have been hit hardest by COVID-19",
+        )

--- a/website/volunteers/tests.py
+++ b/website/volunteers/tests.py
@@ -1,3 +1,16 @@
-# from django.test import TestCase
+from django.urls import reverse
+from django.test import TestCase
 
-# Create your tests here.
+from website.test_helper import TestHelper
+
+
+class ChefSignupListViewTest(TestHelper, TestCase):
+    def test_something(self):
+        self.with_user(groups=["Chefs"])
+        url = reverse("volunteers:chef_signup_list")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            "Sign up to cook meals",
+        )

--- a/website/website/test_helper.py
+++ b/website/website/test_helper.py
@@ -1,0 +1,28 @@
+from django.contrib.auth.models import Group, User
+
+
+# Include in tests to add helpful methods
+# eg.
+#
+# from django.test import TestCase
+# from website.test_helper import TestHelper
+#
+# class MyFancyTest(TestHelper, TestCase):
+#     def test_something(self):
+#         self.with_user(groups=['Chefs'])
+#         self.get(...)
+#
+class TestHelper:
+    # Creates and logs in a user, optionally assigns them the named groups
+    # eg. self.with_user(groups=["Chefs"])
+    def with_user(self, groups=[]):
+        user, _ = User.objects.get_or_create(
+            username="test@example.com", password="test@example.com"
+        )
+
+        for group_name in groups:
+            group, _ = Group.objects.get_or_create(name=group_name)
+            user.groups.add(group)
+
+        self.client.force_login(user)
+        return user

--- a/website/website/test_settings.py
+++ b/website/website/test_settings.py
@@ -1,0 +1,7 @@
+# This module is used for overriding settings when running tests
+# We re-export all the usual settings values, but override some specific ones
+from .settings import *  # noqa: F401,F403
+
+# Disable HTTPS redirect when testing
+# This prevents TestCase#client.get from redirecting to https://
+SECURE_SSL_REDIRECT = False


### PR DESCRIPTION
Setup needed for #430 
Co-Authored by @NatMorcos 

We're going to add a few tests to some of the views, and since its the first time we're doing that we also need to do a bit of setup. There's a new test settings file that disables the HTTPS redirect and there's a new `TestHelpers` mixin that makes it easy to log a user in with particular groups.

I'm going to push this as a PR to make the testing easier on Nat's branch to tackle #430 